### PR TITLE
feat: add automated binary releases with versioning on main branch merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v1.0.0, v0.0.1)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git describe
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Get version from tag
+        id: get_version
+        run: |
+          # Get the tag that triggered this workflow
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          # Remove 'v' prefix if present for version string
+          VERSION=${TAG_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+          echo "Tag: $TAG_NAME"
+
+      - name: Build Linux binary
+        run: |
+          GOOS=linux GOARCH=amd64 go build \
+            -ldflags "-X main.version=${{ steps.get_version.outputs.version }} -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            -o gateway-${{ steps.get_version.outputs.version }}-linux-amd64 \
+            ./cmd/server
+
+      - name: Build Windows binary
+        run: |
+          GOOS=windows GOARCH=amd64 go build \
+            -ldflags "-X main.version=${{ steps.get_version.outputs.version }} -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            -o gateway-${{ steps.get_version.outputs.version }}-windows-amd64.exe \
+            ./cmd/server
+
+      - name: Build macOS binary (amd64)
+        run: |
+          GOOS=darwin GOARCH=amd64 go build \
+            -ldflags "-X main.version=${{ steps.get_version.outputs.version }} -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            -o gateway-${{ steps.get_version.outputs.version }}-darwin-amd64 \
+            ./cmd/server
+
+      - name: Build macOS binary (arm64)
+        run: |
+          GOOS=darwin GOARCH=arm64 go build \
+            -ldflags "-X main.version=${{ steps.get_version.outputs.version }} -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            -o gateway-${{ steps.get_version.outputs.version }}-darwin-arm64 \
+            ./cmd/server
+
+      - name: Create checksums
+        run: |
+          sha256sum gateway-* > checksums.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: Release ${{ steps.get_version.outputs.tag }}
+          body: |
+            ## Release ${{ steps.get_version.outputs.tag }}
+            
+            ### Binaries
+            
+            - `gateway-${{ steps.get_version.outputs.version }}-linux-amd64` - Linux (amd64)
+            - `gateway-${{ steps.get_version.outputs.version }}-windows-amd64.exe` - Windows (amd64)
+            - `gateway-${{ steps.get_version.outputs.version }}-darwin-amd64` - macOS (Intel)
+            - `gateway-${{ steps.get_version.outputs.version }}-darwin-arm64` - macOS (Apple Silicon)
+            
+            ### Checksums
+            
+            See `checksums.txt` for SHA256 checksums of all binaries.
+          files: |
+            gateway-*
+            checksums.txt
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+.PHONY: build run clean test
+
+# Binary name
+BINARY_NAME=gateway
+
+# Get version from git tag or use dev
+VERSION := $(shell git describe --tags --exact-match HEAD 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+VERSION := $(shell echo $(VERSION) | sed 's/^v//')
+BUILD_TIME := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS := -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)
+
+# Build the application
+build:
+	@echo "Building $(BINARY_NAME) (version: $(VERSION))..."
+	@go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/server
+	@echo "Build complete: $(BINARY_NAME)"
+
+# Run the application
+run: build
+	@echo "Running $(BINARY_NAME)..."
+	@./$(BINARY_NAME)
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning..."
+	@rm -f $(BINARY_NAME)
+	@go clean
+	@echo "Clean complete"
+
+# Run tests
+test:
+	@echo "Running tests..."
+	@go test ./...
+
+# Build for Linux
+build-linux:
+	@echo "Building for Linux (version: $(VERSION))..."
+	@GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-$(VERSION)-linux-amd64 ./cmd/server
+
+# Build for Windows
+build-windows:
+	@echo "Building for Windows (version: $(VERSION))..."
+	@GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-$(VERSION)-windows-amd64.exe ./cmd/server
+
+# Build for macOS (Intel)
+build-darwin:
+	@echo "Building for macOS Intel (version: $(VERSION))..."
+	@GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-$(VERSION)-darwin-amd64 ./cmd/server
+
+# Build for macOS (Apple Silicon)
+build-darwin-arm64:
+	@echo "Building for macOS Apple Silicon (version: $(VERSION))..."
+	@GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-$(VERSION)-darwin-arm64 ./cmd/server
+
+# Build for all platforms
+build-all: build-linux build-windows build-darwin build-darwin-arm64
+	@echo "Build complete for all platforms (version: $(VERSION))"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,23 @@
 package main
 
-import "github.com/atozi-ai/gateway/internal/app"
+import (
+	"fmt"
+	"os"
+
+	"github.com/atozi-ai/gateway/internal/app"
+)
+
+var (
+	version   = "dev"
+	buildTime = "unknown"
+)
 
 func main() {
+	// Print version if requested
+	if len(os.Args) > 1 && (os.Args[1] == "-v" || os.Args[1] == "--version" || os.Args[1] == "version") {
+		fmt.Printf("gateway version %s (built at %s)\n", version, buildTime)
+		os.Exit(0)
+	}
+
 	app.Start()
 }


### PR DESCRIPTION
- Add GitHub Actions workflow to build and release binaries on push to main
- Include version in binary filenames (gateway-{version}-{platform}-{arch})
- Build binaries for Linux, Windows, macOS Intel, and macOS Apple Silicon
- Embed version and build time in binaries via ldflags
- Add version flag support to binary (-v, --version, version)
- Update Makefile to include versioning in build-all target
- Generate SHA256 checksums for all release binaries
- Automatically create GitHub releases with versioned binaries