### PR TITLE
feat(providers): add zai provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+gateway
 
 # Test binary, built with `go test -c`
 *.test

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/atozi-ai/gateway/internal/domain/llm"
 	"github.com/atozi-ai/gateway/internal/providers/openai"
 	"github.com/atozi-ai/gateway/internal/providers/xai"
+	"github.com/atozi-ai/gateway/internal/providers/zai"
 )
 
 // Get parses a qualified model name ("provider/model") and returns the
@@ -27,6 +28,8 @@ func Get(qualifiedModel string, apiKey string) (llm.Provider, string, error) {
 		return openai.New(apiKey), model, nil
 	case "xai":
 		return xai.New(apiKey), model, nil
+	case "zai":
+		return zai.New(apiKey), model, nil
 	default:
 		return nil, "", &llm.ProviderError{
 			StatusCode: 400,

--- a/internal/providers/zai/zai.go
+++ b/internal/providers/zai/zai.go
@@ -1,0 +1,35 @@
+package zai
+
+import (
+	"context"
+
+	"github.com/atozi-ai/gateway/internal/domain/llm"
+	"github.com/atozi-ai/gateway/internal/providers/openai_compat"
+)
+
+const baseURL = "https://api.z.ai/api/paas/v4"
+
+// Provider implements llm.Provider for the Z.ai API.
+type Provider struct {
+	client *openaicompat.Client
+}
+
+// New creates an Z.ai provider with the given API key.
+func New(apiKey string) *Provider {
+	return &Provider{
+		client: openaicompat.NewClient(openaicompat.Config{
+			BaseURL: baseURL,
+			APIKey:  apiKey,
+		}),
+	}
+}
+
+func (p *Provider) Name() string { return "zai" }
+
+func (p *Provider) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	return p.client.Chat(ctx, req)
+}
+
+func (p *Provider) ChatStream(ctx context.Context, req llm.ChatRequest, callback func(*llm.StreamChunk) error) error {
+	return p.client.ChatStream(ctx, req, callback)
+}


### PR DESCRIPTION
feat(providers): add zai provider support

Add zai provider to the provider registry, enabling routing
requests to zai models through the gateway.

- Supports: chat/completions